### PR TITLE
[Feature] Send group message

### DIFF
--- a/src/rest/rest.ts
+++ b/src/rest/rest.ts
@@ -11,6 +11,12 @@ function createAPIError(message: string, endpoint: URL, options: any, response: 
     return new Error(`${message}\n-- Endpoint: ${endpoint}\n-- Options: ${inspect(options)}\n-- Response: ${inspect(response)}`);
 }
 
+function* i() {
+    let i = 1;
+    while (true)
+        yield i++ % 10000000;
+}
+
 type HttpMethod = "GET" | "POST";
 
 type RequestOptions = {
@@ -22,9 +28,11 @@ type RequestOptions = {
 
 export default class RESTManager {
     static BASE_URL = "https://api.groupme.com/v3/"
-    client: Client;
+    public client: Client;
+    private generator: Generator<number, void, unknown>;
     constructor(client: Client) {
         this.client = client;
+        this.generator = i();
     }
 
     async api<T>(method: HttpMethod, path: string, data?: RequestOptions): Promise<T>;
@@ -67,82 +75,8 @@ export default class RESTManager {
         return result;
     }
 
+    guid(): string {
+        return 'node-groupme_' + this.generator.next().value;
+    }
+
 }
-
-// type GroupsIndexResponse = {
-//     id: string,
-//     group_id: string,
-//     name: string,
-//     phone_number: string,
-//     type: string,
-//     description: string,
-//     image_url: string,
-//     creator_user_id: string,
-//     created_at: number,
-//     updated_at: number,
-//     muted_until: number,
-//     office_mode: boolean,
-//     share_url: string,
-//     share_qr_code_url: string,
-//     members: {
-//         user_id: string,
-//         nickname: string,
-//         image_url: string,
-//         id: string,
-//         muted: boolean,
-//         autokicked: boolean,
-//         roles: ["admin", "owner"] | ["admin"] | ["user"],
-//         name: string,
-//     }[] | null,
-//     messages: {
-//         count: number,
-//         last_message_id: string,
-//         last_message_created_at: number,
-//         preview: {
-//             nickname: string,
-//             text: string,
-//             image_url: string,
-//             attachments: Attachment[],
-//         }
-//     },
-//     max_members: number,
-//     theme_name: string | null,
-//     like_icon: {
-//         type: "emoji",
-//         packId: number,
-//         packIndex: number
-//     } | null;
-//     message_deletion_period: number,
-//     message_deletion_mode: string[],
-//     requires_approval: boolean,
-//     show_join_question: boolean,
-//     join_question: null // just pretend that this will never exist :clueless:
-// }[];
-
-// type ChatsIndexResponse = {
-//     created_at: number,
-//     updated_at: number,
-//     messages_count: number,
-//     message_deletion_period: number,
-//     message_deletion_mode: string[],
-//     last_message: {
-//         attachments: Attachment[],
-//         avatar_url: string,
-//         conversation_id: string,
-//         created_at: number,
-//         favorited_by: [], // This seems to always be empty
-//         id: string,
-//         name: string,
-//         recipient_id: string,
-//         sender_id: string,
-//         sender_type: string,
-//         source_guid: string,
-//         text: string,
-//         user_id: string,
-//     },
-//     other_user: {
-//         avatar_url: string,
-//         id: string,
-//         name: string,
-//     },
-// }[];

--- a/src/rest/rest.ts
+++ b/src/rest/rest.ts
@@ -53,7 +53,10 @@ export default class RESTManager {
         init.headers = new Headers();
         init.headers.set('X-Access-Token', this.client.token);
         init.method = method;
-        if (data?.body) init.body = data.body;
+        if (data?.body) {
+            init.headers.set('Content-Type', 'application/json');
+            init.body = JSON.stringify(data.body);
+        }
 
         const response = await fetch(url, init);
         console.log(`-----\nAPI request\nurl: ${url}\n-----`)

--- a/src/structures/Channel.ts
+++ b/src/structures/Channel.ts
@@ -56,5 +56,5 @@ export default abstract class Channel implements ChannelData {
 
 export interface SendableChannelInterface {
     messages: MessageManager<Channel, Message>;
-    send(message: Message): Promise<Message>;
+    send(text: string): Promise<Message>;
 }

--- a/src/structures/Chat.ts
+++ b/src/structures/Chat.ts
@@ -5,7 +5,7 @@ import { ChannelType } from "./Channel";
 import type ChatMessage from "./ChatMessage";
 
 interface ChatInterface {
-    send(message: Message): Promise<ChatMessage>
+    send(text: string): Promise<ChatMessage>
 
 }
 
@@ -38,7 +38,7 @@ export default class Chat extends Channel implements ChatInterface, SendableChan
         this.recipient = user;
         this.messages = new ChatMessageManager(client, this)
     }
-    send(message: Message): Promise<ChatMessage> {
+    send(text: string): Promise<ChatMessage> {
         throw new Error("Method not implemented.");
     }
 }

--- a/src/structures/Group.ts
+++ b/src/structures/Group.ts
@@ -1,10 +1,10 @@
-import type { APIGroup } from "groupme-api-types";
+import type { APIGroup, PostGroupMessageBody, PostGroupMessageResponse } from "groupme-api-types";
 import type { Client, FormerGroup, Member, Message, SendableChannelInterface } from "..";
 import GroupMessageManager from "../managers/GroupMessageManager";
 import PollManager from "../managers/PollManager";
 import BaseGroup from "./BaseGroup";
 import { ChannelType } from "./Channel";
-import type GroupMessage from "./GroupMessage";
+import GroupMessage from "./GroupMessage";
 
 type GroupUpdateOptions = {
     name: string
@@ -39,42 +39,68 @@ export default class Group extends BaseGroup implements ActiveGroupInterface, Se
         this.messages = new GroupMessageManager(client, this);
         this.polls = new PollManager(client, this);
     }
-    send(message: Message): Promise<GroupMessage> {
-        throw new Error("Method not implemented.");
+
+    public async send(text: string): Promise<GroupMessage> {
+        const body: PostGroupMessageBody = {
+            message: {
+                text,
+                attachments: [],
+                source_guid: this.client.rest.guid(),
+            }
+        };
+        const response = await this.client.rest.api<PostGroupMessageResponse>(
+            'POST',
+            `groups/${this.id}/messages`,
+            { body }
+        );
+        const message = new GroupMessage(this.client, this, response.message);
+        return this.messages._upsert(message);
     }
+
     fetch(): Promise<this> {
         throw new Error("Method not implemented.");
     }
+
     update(options: GroupUpdateOptions): Promise<this> {
         throw new Error("Method not implemented.");
     }
+
     transferOwnershipTo(newOwner: string): Promise<this> {
         throw new Error("Method not implemented.");
     }
+
     delete(): Promise<void> {
         throw new Error("Method not implemented.");
     }
+
     changeNickname(nickname: string): Promise<Member> {
         throw new Error("Method not implemented.");
     }
+
     leave(): Promise<FormerGroup> {
         throw new Error("Method not implemented.");
     }
+
     get canLeave(): boolean {
         throw new Error("Method not implemented.");
     }
+
     get canUpdate(): boolean {
         throw new Error("Method not implemented.");
     }
+
     get canDelete(): boolean {
         throw new Error("Method not implemented.");
     }
+
     get canTransfer(): boolean {
         throw new Error("Method not implemented.");
     }
+
     get canAddMembers(): boolean {
         throw new Error("Method not implemented.");
     }
+
     get canRemoveMembers(): boolean {
         throw new Error("Method not implemented.");
     }

--- a/src/structures/Group.ts
+++ b/src/structures/Group.ts
@@ -20,7 +20,7 @@ interface ActiveGroupInterface {
     transferOwnershipTo(newOwner: string): Promise<this>
     delete(): Promise<void>
     changeNickname(nickname: string): Promise<Member>
-    send(message: Message): Promise<GroupMessage>
+    send(text: string): Promise<GroupMessage>
     leave(): Promise<FormerGroup>
     get canLeave(): boolean
     get canUpdate(): boolean


### PR DESCRIPTION
This PR includes implementations for `Group#send(text: string)` and some REST stuff to make this work.

note: `Group#send()` (and more broadly, `SendableChannelInterface#send()`) need additional overloads for sending attachments etc.