### PR TITLE
Move docs repo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          publish_branch: docs
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          publish_branch: main
+          personal_token: ${{ secrets.PERSONAL_TOKEN }}
           cname: groupme.js.org
+          external_repository: groupme-js/website


### PR DESCRIPTION
To do before merge:

- [ ] Move the groupme.js.org link to the docs repo (PR in the js.org repo)
- [x] Add a secret to the node-groupme repo using a PAT from your account or another account that has maintain permissions for the docs repo. Use the key `PERSONAL_TOKEN`