### PR TITLE
[Feature] Send chat message

### DIFF
--- a/src/structures/Group.ts
+++ b/src/structures/Group.ts
@@ -51,7 +51,7 @@ export default class Group extends BaseGroup implements ActiveGroupInterface, Se
         const response = await this.client.rest.api<PostGroupMessageResponse>(
             'POST',
             `groups/${this.id}/messages`,
-            { body }
+            { body },
         );
         const message = new GroupMessage(this.client, this, response.message);
         return this.messages._upsert(message);


### PR DESCRIPTION
This PR implements `Chat#send(text: string)`.

note: `Chat#send()`, `Group#send()`, and more broadly, `SendableChannelInterface#send()` need additional overloads for sending attachments etc.