### PR TITLE
[Feature] Implement group methods and member permission getters

### DIFF
--- a/src/structures/BaseGroup.ts
+++ b/src/structures/BaseGroup.ts
@@ -6,7 +6,7 @@ export default abstract class BaseGroup extends Channel {
     readonly members: MemberManager;
     name: string;
     phoneNumber: string | null;
-    private: boolean;
+    closed: boolean;
     imageURL: string | null;
     creatorID: string;
     mutedUntil?: number | null;
@@ -46,7 +46,7 @@ export default abstract class BaseGroup extends Channel {
         this.members = new MemberManager(this.client, this);
         this.name = data.name;
         this.phoneNumber = data.phone_number;
-        this.private = data.type == "private";
+        this.closed = data.type == "closed";
         this.imageURL = data.image_url;
         this.creatorID = data.creator_user_id;
         this.mutedUntil = data.muted_until;

--- a/src/structures/Group.ts
+++ b/src/structures/Group.ts
@@ -75,6 +75,8 @@ export default class Group extends BaseGroup implements ActiveGroupInterface, Se
         throw new Error("Method not implemented.");
     }
 
+    public get me(): Member | undefined {
+        return this.members.cache.get(this.client.user.id);
     }
 
 }

--- a/src/structures/Group.ts
+++ b/src/structures/Group.ts
@@ -15,7 +15,7 @@ type GroupUpdateOptions = {
 }
 
 interface ActiveGroupInterface {
-    fetch(): Promise<this>
+    fetch(): Promise<Group>
     update(options: GroupUpdateOptions): Promise<this>
     transferOwnershipTo(newOwner: string): Promise<this>
     delete(): Promise<void>
@@ -51,8 +51,8 @@ export default class Group extends BaseGroup implements ActiveGroupInterface, Se
         return this.messages._upsert(message);
     }
 
-    fetch(): Promise<this> {
-        throw new Error("Method not implemented.");
+    fetch(): Promise<Group> {
+        return this.client.groups.fetch(this.id);
     }
 
     update(options: GroupUpdateOptions): Promise<this> {

--- a/src/structures/Group.ts
+++ b/src/structures/Group.ts
@@ -1,4 +1,8 @@
-import type { APIGroup, PostGroupMessageBody, PostGroupMessageResponse } from "groupme-api-types";
+import type {
+    APIGroup,
+    PostGroupMessageBody, PostGroupMessageResponse,
+    PatchGroupBody, PatchGroupResponse,
+} from "groupme-api-types";
 import type { Client, FormerGroup, Member, Message, SendableChannelInterface } from "..";
 import GroupMessageManager from "../managers/GroupMessageManager";
 import PollManager from "../managers/PollManager";
@@ -16,8 +20,8 @@ type GroupUpdateOptions = {
 
 interface ActiveGroupInterface {
     fetch(): Promise<Group>
-    update(options: GroupUpdateOptions): Promise<this>
-    transferOwnershipTo(newOwner: string): Promise<this>
+    update(options: GroupUpdateOptions): Promise<Group>
+    transferOwnershipTo(newOwner: string): Promise<Group>
     delete(): Promise<void>
     changeNickname(nickname: string): Promise<Member>
     send(text: string): Promise<GroupMessage>
@@ -55,8 +59,15 @@ export default class Group extends BaseGroup implements ActiveGroupInterface, Se
         return this.client.groups.fetch(this.id);
     }
 
-    update(options: GroupUpdateOptions): Promise<this> {
-        throw new Error("Method not implemented.");
+    async update(options: GroupUpdateOptions): Promise<Group> {
+        const body: PatchGroupBody = options;
+        const response = await this.client.rest.api<PatchGroupResponse>(
+            'POST',
+            `groups/${this.id}/update`,
+            { body },
+        );
+        const group = new Group(this.client, response);
+        return this.client.groups._upsert(group);
     }
 
     transferOwnershipTo(newOwner: string): Promise<this> {

--- a/src/structures/Group.ts
+++ b/src/structures/Group.ts
@@ -22,12 +22,6 @@ interface ActiveGroupInterface {
     changeNickname(nickname: string): Promise<Member>
     send(text: string): Promise<GroupMessage>
     leave(): Promise<FormerGroup>
-    get canLeave(): boolean
-    get canUpdate(): boolean
-    get canDelete(): boolean
-    get canTransfer(): boolean
-    get canAddMembers(): boolean
-    get canRemoveMembers(): boolean
 }
 
 export default class Group extends BaseGroup implements ActiveGroupInterface, SendableChannelInterface {
@@ -81,28 +75,6 @@ export default class Group extends BaseGroup implements ActiveGroupInterface, Se
         throw new Error("Method not implemented.");
     }
 
-    get canLeave(): boolean {
-        throw new Error("Method not implemented.");
-    }
-
-    get canUpdate(): boolean {
-        throw new Error("Method not implemented.");
-    }
-
-    get canDelete(): boolean {
-        throw new Error("Method not implemented.");
-    }
-
-    get canTransfer(): boolean {
-        throw new Error("Method not implemented.");
-    }
-
-    get canAddMembers(): boolean {
-        throw new Error("Method not implemented.");
-    }
-
-    get canRemoveMembers(): boolean {
-        throw new Error("Method not implemented.");
     }
 
 }

--- a/src/structures/Member.ts
+++ b/src/structures/Member.ts
@@ -7,12 +7,9 @@ interface MemberInterface {
 }
 
 export default class Member implements MemberInterface {
-    private readonly _user: User;
-    private readonly _group: BaseGroup;
-    private readonly _memberID: string;
-    public get user(): User { return this._user }
-    public get group(): BaseGroup { return this._group }
-    public get memberID(): string { return this._memberID }
+    readonly user: User;
+    readonly group: BaseGroup;
+    readonly memberID: string;
     readonly client: Client;
     readonly id: string;
     nickname: string;
@@ -23,9 +20,9 @@ export default class Member implements MemberInterface {
     constructor(client: Client, group: BaseGroup, user: User, data: APIMember) {
         this.client = client;
         this.id = user.id;
-        this._user = user;
-        this._group = group;
-        this._memberID = data.id;
+        this.user = user;
+        this.group = group;
+        this.memberID = data.id;
         this.nickname = data.nickname;
         this.muted = data.muted;
         this.autokicked = data.autokicked;

--- a/src/structures/Member.ts
+++ b/src/structures/Member.ts
@@ -20,10 +20,6 @@ export default class Member implements MemberInterface {
     autokicked: boolean;
     roles: ("admin" | "owner" | "user")[];
 
-    public get isAdmin(): boolean {
-        return this.roles.includes("admin");
-    }
-
     constructor(client: Client, group: BaseGroup, user: User, data: APIMember) {
         this.client = client;
         this.id = user.id;
@@ -34,5 +30,37 @@ export default class Member implements MemberInterface {
         this.muted = data.muted;
         this.autokicked = data.autokicked;
         this.roles = data.roles;
+    }
+
+    get isAdmin(): boolean {
+        return this.roles.includes("admin") || this.isOwner;
+    }
+
+    get isOwner(): boolean {
+        return this.user.id === this.group.creatorID;
+    }
+
+    get canLeaveGroup(): boolean {
+        return !this.isOwner;
+    }
+
+    get canUpdateGroup(): boolean {
+        return this.isAdmin || !this.group.closed;
+    }
+
+    get canAddMembers(): boolean {
+        return this.isAdmin || !this.group.closed;
+    }
+
+    get canRemoveMembers(): boolean {
+        return this.isAdmin || !this.group.closed;
+    }
+
+    get canDeleteGroup(): boolean {
+        return this.isOwner;
+    }
+
+    get canTransferGroup(): boolean {
+        return this.isOwner;
     }
 }


### PR DESCRIPTION
This PR replaces property `Group#private` with `Group#closed`, and ​implements the following Group methods/getters:
- `Group#fetch()`
- `Group#update()`
- `Group#transferOwnershipTo()`
- `Group#me`

Additionally, it implements the following permission checkers for Members:
- `Member#isAdmin`
- `Member#isOwner`
- `Member#canLeaveGroup`
- `Member#canUpdateGroup`
- `Member#canAddMembers`
- `Member#canRemoveMembers`
- `Member#canDeleteGroup`
- `Member#canTransferGroup`