### PR TITLE
Update package.json scripts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
               run: npm install
 
             - name: Compile using TSC
-              run: npm run build
+              run: npm run compile
 
             - name: Run tests
               run: npm run test

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,41 +2,31 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"type": "typescript",
-			"tsconfig": "tsconfig.json",
-			"option": "watch",
-			"problemMatcher": [
-				"$tsc-watch"
-			],
-			"group": "build",
-			"label": "tsc: watch - tsconfig.json"
-		},
-		{
-			"type": "typescript",
-			"tsconfig": "tsconfig.json",
-			"problemMatcher": [
-				"$tsc"
-			],
-			"group": "build",
-			"label": "tsc: build - tsconfig.json"
-		},
-		{
-			"type": "shell",
-			"options": {
-				"cwd": "${workspaceFolder}"
-			},
-			"command": [
-				"cmd /c rmdir /s /q dist;",
-				"npm pack;",
-				"mv -force ./node-groupme-*.tgz ../node-groupme-test/node-groupme.tgz;",
-				"cd ../node-groupme-test/;",
-				"npm i ./node-groupme.tgz;"
-			],
-			"label": "compile and send to test env",
+			"type": "npm",
+			"script": "compile",
 			"group": {
 				"kind": "build",
 				"isDefault": true
 			},
-		}
+			"problemMatcher": [],
+			"label": "Build",
+			"detail": "Clean and recompile the project"
+		},
+		{
+			"type": "npm",
+			"script": "test",
+			"group": "test",
+			"problemMatcher": [],
+			"label": "Test",
+			"detail": "Run the test suite"
+		},
+		{
+			"type": "npm",
+			"script": "watch",
+			"group": "build",
+			"problemMatcher": [],
+			"label": "Build and Watch",
+			"detail": "Live build the project on every change"
+		},
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,32 +1,44 @@
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"type": "npm",
-			"script": "compile",
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
-			"problemMatcher": [],
-			"label": "Build",
-			"detail": "Clean and recompile the project"
-		},
-		{
-			"type": "npm",
-			"script": "test",
-			"group": "test",
-			"problemMatcher": [],
-			"label": "Test",
-			"detail": "Run the test suite"
-		},
-		{
-			"type": "npm",
-			"script": "watch",
-			"group": "build",
-			"problemMatcher": [],
-			"label": "Build and Watch",
-			"detail": "Live build the project on every change"
-		},
-	]
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "clean",
+            "detail": "Delete the /dist folder",
+            "type": "shell",
+            "presentation": {
+                "showReuseMessage": false,
+            },
+            "windows": {
+                "command": "cmd /c rmdir /s /q dist",
+            },
+            "linux": {
+                "command": "rm -rf dist",
+            },
+            "osx": {
+                "command": "rm -rf dist",
+            },
+            "group": "build",
+        },
+        {
+            "label": "tsc: build",
+            "detail": "Compile with tsc, cleaning old files if necessary",
+            "dependsOn": "clean",
+            "type": "typescript",
+            "tsconfig": "tsconfig.json",
+            "problemMatcher": "$tsc",
+            "group": {
+                "kind": "build",
+                "isDefault": true,
+            },
+        },
+        {
+            "label": "tsc: watch",
+            "detail": "Start tsc in watch mode, compiling every time you save. Does NOT clean between compilations!",
+            "option": "watch",
+            "type": "typescript",
+            "tsconfig": "tsconfig.json",
+            "problemMatcher": "$tsc-watch",
+            "group": "build",
+        },
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "version": "0.0.3",
   "description": "The only GroupMe API library that isn't a million years old.",
   "main": "dist/index.js",
-  "scripts": {
-    "test": "mocha \"tests/**/*.js\" --forbid-only --bail --recursive --require tests/hooks.js",
-    "build": "npx tsc",
+  "scripts": {    
+    "clean": "rm -rf dist",
+    "compile": "npm run clean && tsc -p .",
+    "docs": "typedoc --theme ./node_modules/typedoc-neo-theme/bin/default",
     "prepare": "husky install",
-    "docs": "typedoc --theme ./node_modules/typedoc-neo-theme/bin/default"
+    "prepublishOnly": "npm run compile",
+    "test": "mocha \"tests/**/*.js\" --forbid-only --bail --recursive --require tests/hooks.js",
+    "watch": "tsc -w -p ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# New Scripts
Clean - removes the old output from `tsc`
Compile - run clean and then run tsc
Docs - generate the documentation into the `docs` folder
Prepare - install the git hooks from husky
Pre-Publish Only - run compile (this is run right before the package is published)
Test - run the full test suite
Watch - live compile using `tsc` as changes are made


A lot of this layout was taken from other typescript packages
npm will automatically publish the dist folder for the package and prepublishOnly will ensure that its the newest build