### PR TITLE
style: line endings and new prettier rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,9 @@
   "semi": false,
   "useTabs": false,
   "proseWrap": "never",
-  "printWidth": 250
+  "printWidth": 120,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "endOfLine": "lf",
+  "arrowParens": "avoid"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@discordjs/collection": "^0.1.6",
-        "groupme-api-types": "^0.8.2",
+        "groupme-api-types": "^0.9.0",
         "node-fetch": "^2.6.1",
         "ws": "^8.1.0"
       },
@@ -734,10 +734,16 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -1530,9 +1536,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -1603,9 +1609,9 @@
       "dev": true
     },
     "node_modules/groupme-api-types": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/groupme-api-types/-/groupme-api-types-0.8.2.tgz",
-      "integrity": "sha512-1uCYdAvbOgk06cQg7vwRbjC5LGlZKfI8kvCexvMbpA/z4sDO+RjjkcbLr+QrdW78qDcZi1fU6VqmlJXmYHHKDw=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/groupme-api-types/-/groupme-api-types-0.9.0.tgz",
+      "integrity": "sha512-pSxMuLWMHeog0Ar+06IPLVMPkDu5UbONG2+zegGLGwqK+v7swyNANWiFVxsm+Sa9UPdI/iQm5XHQg8luN1HohA=="
     },
     "node_modules/growl": {
       "version": "1.10.5",
@@ -2233,32 +2239,32 @@
       "dev": true
     },
     "node_modules/mocha": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.4.tgz",
-      "integrity": "sha512-+q2aV5VlJZuLgCWoBvGI5zEwPF9eEI0kr/sAA9Jm4xMND7RfIEyF8JE7C0JIg8WXRG+P1sdIAb5ccoHPlXLzcw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
+      "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.5.2",
-        "debug": "4.3.2",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
-        "glob": "7.1.7",
+        "glob": "7.2.0",
         "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.25",
+        "nanoid": "3.2.0",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "workerpool": "6.1.5",
+        "workerpool": "6.2.0",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
@@ -2274,29 +2280,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/mochajs"
       }
-    },
-    "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mocha/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/mocha/node_modules/ms": {
       "version": "2.1.3",
@@ -2326,9 +2309,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -3332,9 +3315,9 @@
       "dev": true
     },
     "node_modules/workerpool": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
       "dev": true
     },
     "node_modules/wrap-ansi": {
@@ -3954,9 +3937,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
@@ -4554,9 +4537,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -4606,9 +4589,9 @@
       "dev": true
     },
     "groupme-api-types": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/groupme-api-types/-/groupme-api-types-0.8.2.tgz",
-      "integrity": "sha512-1uCYdAvbOgk06cQg7vwRbjC5LGlZKfI8kvCexvMbpA/z4sDO+RjjkcbLr+QrdW78qDcZi1fU6VqmlJXmYHHKDw=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/groupme-api-types/-/groupme-api-types-0.9.0.tgz",
+      "integrity": "sha512-pSxMuLWMHeog0Ar+06IPLVMPkDu5UbONG2+zegGLGwqK+v7swyNANWiFVxsm+Sa9UPdI/iQm5XHQg8luN1HohA=="
     },
     "growl": {
       "version": "1.10.5",
@@ -5068,54 +5051,37 @@
       "dev": true
     },
     "mocha": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.4.tgz",
-      "integrity": "sha512-+q2aV5VlJZuLgCWoBvGI5zEwPF9eEI0kr/sAA9Jm4xMND7RfIEyF8JE7C0JIg8WXRG+P1sdIAb5ccoHPlXLzcw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
+      "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.5.2",
-        "debug": "4.3.2",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
-        "glob": "7.1.7",
+        "glob": "7.2.0",
         "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.25",
+        "nanoid": "3.2.0",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "workerpool": "6.1.5",
+        "workerpool": "6.2.0",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            }
-          }
-        },
         "ms": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5140,9 +5106,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
       "dev": true
     },
     "natural-compare": {
@@ -5833,9 +5799,9 @@
       "dev": true
     },
     "workerpool": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.3",
   "description": "The only GroupMe API library that isn't a million years old.",
   "main": "dist/index.js",
-  "scripts": {    
+  "scripts": {
     "clean": "rm -rf dist",
     "compile": "npm run clean && tsc -p .",
     "docs": "typedoc --theme ./node_modules/typedoc-neo-theme/bin/default",
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@discordjs/collection": "^0.1.6",
-    "groupme-api-types": "^0.8.2",
+    "groupme-api-types": "^0.9.0",
     "node-fetch": "^2.6.1",
     "ws": "^8.1.0"
   },

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -1,11 +1,11 @@
-import EventEmitter from "events"
-import type { APIClientUser } from "groupme-api-types"
-import ChatManager from "../managers/ChatManager"
-import GroupManager from "../managers/GroupManager"
-import UserManager from "../managers/UserManager"
-import RESTManager from "../rest/rest"
-import WS from "../util/Websocket"
-import ClientUser from "./ClientUser"
+import EventEmitter from 'events'
+import type { APIClientUser } from 'groupme-api-types'
+import ChatManager from '../managers/ChatManager'
+import GroupManager from '../managers/GroupManager'
+import UserManager from '../managers/UserManager'
+import RESTManager from '../rest/rest'
+import WS from '../util/Websocket'
+import ClientUser from './ClientUser'
 
 interface ClientInterface {
     groups: GroupManager
@@ -34,7 +34,7 @@ export default class Client extends EventEmitter implements ClientInterface {
         this.ws = new WS(this)
     }
     login = async (): Promise<Client> => {
-        const me = await this.rest.api<APIClientUser>("GET", "users/me")
+        const me = await this.rest.api<APIClientUser>('GET', 'users/me')
         this.user = new ClientUser(this, {
             avatar: me.image_url,
             id: me.user_id,

--- a/src/client/ClientUser.ts
+++ b/src/client/ClientUser.ts
@@ -1,5 +1,5 @@
-import type { Client } from ".."
-import User, { UserData } from "../structures/User"
+import type { Client } from '..'
+import User, { UserData } from '../structures/User'
 
 interface ClientUserInterface {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,31 +1,31 @@
-export { Collection } from "./util/Collection"
+export { Collection } from './util/Collection'
 
-export { default as User } from "./structures/User"
-export { default as Message } from "./structures/Message"
-export { default as BaseManager } from "./managers/BaseManager"
-export { default as UserManager } from "./managers/UserManager"
-export { default as MessageLikeManager } from "./managers/MessageLikeManager"
-export { default as Member } from "./structures/Member"
-export { default as FormerMember } from "./structures/FormerMember"
-export { default as FormerMemberManager } from "./managers/FormerMemberManager"
-export { default as MemberManager } from "./managers/MemberManager"
-export { default as Channel, ChannelType, SendableChannelInterface } from "./structures/Channel"
-export { default as BaseGroup } from "./structures/BaseGroup"
-export { default as Poll } from "./structures/Poll"
-export { default as GroupMessage } from "./structures/GroupMessage"
-export { default as MessageManager } from "./managers/MessageManager"
-export { default as ChatMessage } from "./structures/ChatMessage"
-export { default as ChatMessageManager } from "./managers/ChatMessageManager"
-export { default as GroupMessageManager } from "./managers/GroupMessageManager"
-export { default as PollManager } from "./managers/PollManager"
-export { default as FormerGroup } from "./structures/FormerGroup"
-export { default as Chat } from "./structures/Chat"
-export { default as Group } from "./structures/Group"
-export { default as FormerGroupManager } from "./managers/FormerGroupManager"
-export { default as ChatManager } from "./managers/ChatManager"
-export { default as GroupManager } from "./managers/GroupManager"
+export { default as User } from './structures/User'
+export { default as Message } from './structures/Message'
+export { default as BaseManager } from './managers/BaseManager'
+export { default as UserManager } from './managers/UserManager'
+export { default as MessageLikeManager } from './managers/MessageLikeManager'
+export { default as Member } from './structures/Member'
+export { default as FormerMember } from './structures/FormerMember'
+export { default as FormerMemberManager } from './managers/FormerMemberManager'
+export { default as MemberManager } from './managers/MemberManager'
+export { default as Channel, ChannelType, SendableChannelInterface } from './structures/Channel'
+export { default as BaseGroup } from './structures/BaseGroup'
+export { default as Poll } from './structures/Poll'
+export { default as GroupMessage } from './structures/GroupMessage'
+export { default as MessageManager } from './managers/MessageManager'
+export { default as ChatMessage } from './structures/ChatMessage'
+export { default as ChatMessageManager } from './managers/ChatMessageManager'
+export { default as GroupMessageManager } from './managers/GroupMessageManager'
+export { default as PollManager } from './managers/PollManager'
+export { default as FormerGroup } from './structures/FormerGroup'
+export { default as Chat } from './structures/Chat'
+export { default as Group } from './structures/Group'
+export { default as FormerGroupManager } from './managers/FormerGroupManager'
+export { default as ChatManager } from './managers/ChatManager'
+export { default as GroupManager } from './managers/GroupManager'
 
-export { default as Attachment } from "./structures/Attachment"
-export { default as PollOption } from "./structures/PollOption"
+export { default as Attachment } from './structures/Attachment'
+export { default as PollOption } from './structures/PollOption'
 
-export { default as Client } from "./client/Client"
+export { default as Client } from './client/Client'

--- a/src/managers/BaseManager.ts
+++ b/src/managers/BaseManager.ts
@@ -1,5 +1,5 @@
-import type { Client } from ".."
-import { Collection } from ".."
+import type { Client } from '..'
+import { Collection } from '..'
 
 interface Indexable {
     id: string
@@ -16,7 +16,7 @@ export default abstract class BaseManager<T extends Indexable> {
     }
     resolve(data: unknown): T | null {
         if (data instanceof this.holds) return data
-        if (typeof data === "string") return this.cache.get(data) ?? null
+        if (typeof data === 'string') return this.cache.get(data) ?? null
         return null
     }
     resolveId(data: unknown): string | null {

--- a/src/managers/ChatManager.ts
+++ b/src/managers/ChatManager.ts
@@ -1,6 +1,6 @@
-import type { APIChat } from "groupme-api-types"
-import type { Client } from ".."
-import { BaseManager, Chat, Collection, User } from ".."
+import type { APIChat } from 'groupme-api-types'
+import type { Client } from '..'
+import { BaseManager, Chat, Collection, User } from '..'
 
 type ChatsRequestParams = {
     page?: number
@@ -23,8 +23,10 @@ export default class ChatManager extends BaseManager<Chat> implements ChatManage
     fetch(): Promise<Collection<string, Chat>>
     fetch(id: string): Promise<Chat>
     fetch(ids: string[]): Promise<Collection<string, Chat | null>>
-    fetch(ids?: string | string[]): Promise<Collection<string, Chat>> | Promise<Chat> | Promise<Collection<string, Chat | null>> {
-        throw new Error("Method not implemented.")
+    fetch(
+        ids?: string | string[],
+    ): Promise<Collection<string, Chat>> | Promise<Chat> | Promise<Collection<string, Chat | null>> {
+        throw new Error('Method not implemented.')
     }
 
     async fetchChats(options?: { page?: number; per_page?: number }) {
@@ -44,9 +46,9 @@ export default class ChatManager extends BaseManager<Chat> implements ChatManage
         }
 
         const batch = new Collection<string, Chat>()
-        const chats = await this.client.rest.api<APIChat[]>("GET", "chats", { query: apiParams })
+        const chats = await this.client.rest.api<APIChat[]>('GET', 'chats', { query: apiParams })
 
-        chats.forEach((data) => {
+        chats.forEach(data => {
             const chat = this._upsert(
                 new Chat(
                     this.client,
@@ -55,10 +57,10 @@ export default class ChatManager extends BaseManager<Chat> implements ChatManage
                             id: data.other_user.id,
                             name: data.other_user.name,
                             avatar: data.other_user.avatar_url,
-                        })
+                        }),
                     ),
-                    data
-                )
+                    data,
+                ),
             )
             batch.set(chat.recipient.id, chat)
         })

--- a/src/managers/ChatMessageManager.ts
+++ b/src/managers/ChatMessageManager.ts
@@ -1,7 +1,7 @@
-import type { GetChatMessageResponse, GetChatMessagesQuery, GetChatMessagesResponse } from "groupme-api-types"
-import type { Chat, Client } from ".."
-import { ChatMessage, Collection, MessageManager } from ".."
-import type { MessageRequestParams } from "./MessageManager"
+import type { GetChatMessageResponse, GetChatMessagesQuery, GetChatMessagesResponse } from 'groupme-api-types'
+import type { Chat, Client } from '..'
+import { ChatMessage, Collection, MessageManager } from '..'
+import type { MessageRequestParams } from './MessageManager'
 
 export default class ChatMessageManager extends MessageManager<Chat, ChatMessage> {
     constructor(client: Client, channel: Chat) {
@@ -12,12 +12,14 @@ export default class ChatMessageManager extends MessageManager<Chat, ChatMessage
     fetch(id: string): Promise<ChatMessage>
     fetch(ids: string[]): Promise<Collection<string, ChatMessage>>
     fetch(options: MessageRequestParams): Promise<Collection<string, ChatMessage>>
-    public async fetch(options?: string | string[] | MessageRequestParams): Promise<ChatMessage | Collection<string, ChatMessage>> {
-        if (typeof options === "string") {
+    public async fetch(
+        options?: string | string[] | MessageRequestParams,
+    ): Promise<ChatMessage | Collection<string, ChatMessage>> {
+        if (typeof options === 'string') {
             return await this.fetchId(options)
         } else if (Array.isArray(options)) {
             return await this.fetchIds(options)
-        } else if (typeof options === "object") {
+        } else if (typeof options === 'object') {
             return await this.fetchIndex(options)
         } else {
             return await this.fetchAll()
@@ -25,14 +27,16 @@ export default class ChatMessageManager extends MessageManager<Chat, ChatMessage
     }
 
     private async fetchId(id: string): Promise<ChatMessage> {
-        const res = await this.client.rest.api<GetChatMessageResponse>("GET", `direct_messages/${id}`, { query: { other_user_id: this.channel.recipient.id } })
+        const res = await this.client.rest.api<GetChatMessageResponse>('GET', `direct_messages/${id}`, {
+            query: { other_user_id: this.channel.recipient.id },
+        })
         const message = this._upsert(new ChatMessage(this.client, this.channel, res.message))
         return message
     }
 
     private async fetchIds(ids: string[]): Promise<Collection<string, ChatMessage>> {
         const messages = await Promise.all(ids.map<Promise<ChatMessage>>(this.fetchId))
-        const batch = new Collection<string, ChatMessage>(messages.map((m) => [m.id, m]))
+        const batch = new Collection<string, ChatMessage>(messages.map(m => [m.id, m]))
         return batch
     }
 
@@ -44,7 +48,12 @@ export default class ChatMessageManager extends MessageManager<Chat, ChatMessage
         if (options.limit !== undefined) apiParams.limit = options.limit
 
         const batch = new Collection<string, ChatMessage>()
-        const res = await this.client.rest.api<GetChatMessagesResponse>("GET", `direct_messages`, { query: apiParams }, { allowNull: true })
+        const res = await this.client.rest.api<GetChatMessagesResponse>(
+            'GET',
+            `direct_messages`,
+            { query: apiParams },
+            { allowNull: true },
+        )
 
         if (!res) return batch
 

--- a/src/managers/FormerGroupManager.ts
+++ b/src/managers/FormerGroupManager.ts
@@ -1,6 +1,6 @@
-import type { APIGroup } from "groupme-api-types"
-import type { Client } from ".."
-import { BaseManager, Collection, FormerGroup, Member, User } from ".."
+import type { APIGroup } from 'groupme-api-types'
+import type { Client } from '..'
+import { BaseManager, Collection, FormerGroup, Member, User } from '..'
 
 interface FormerGroupManagerInterface {
     client: Client
@@ -14,22 +14,22 @@ export default class FormerGroupManager extends BaseManager<FormerGroup> impleme
     }
 
     public async fetch(): Promise<Collection<string, FormerGroup>> {
-        const groupsFormerResponse = await this.client.rest.api<APIGroup[]>("GET", "groups/former")
+        const groupsFormerResponse = await this.client.rest.api<APIGroup[]>('GET', 'groups/former')
         const batch = new Collection<string, FormerGroup>()
 
-        groupsFormerResponse.forEach((g) => {
+        groupsFormerResponse.forEach(g => {
             /** The Group object to store data in. */
             const formerGroup = this._upsert(new FormerGroup(this.client, g))
 
             // we know that g.members is always defined for former groups
             // however, it would be nice if the types reflected that...
-            g.members!.forEach((data) => {
+            g.members!.forEach(data => {
                 const user = this.client.users._upsert(
                     new User(this.client, {
                         id: data.user_id,
                         avatar: data.image_url,
                         name: data.name,
-                    })
+                    }),
                 )
                 formerGroup.members._upsert(new Member(this.client, formerGroup, user, data))
             })

--- a/src/managers/FormerMemberManager.ts
+++ b/src/managers/FormerMemberManager.ts
@@ -1,5 +1,5 @@
-import type { BaseGroup, Client, Collection } from ".."
-import { BaseManager, FormerMember } from ".."
+import type { BaseGroup, Client, Collection } from '..'
+import { BaseManager, FormerMember } from '..'
 
 interface FormerMemberManagerInterface {
     fetch(): Promise<Collection<string, FormerMember>>
@@ -12,6 +12,6 @@ export default class FormerMemberManager extends BaseManager<FormerMember> imple
         this.group = group
     }
     fetch(): Promise<Collection<string, FormerMember>> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
 }

--- a/src/managers/GroupManager.ts
+++ b/src/managers/GroupManager.ts
@@ -1,11 +1,11 @@
-import type { APIGroup } from "groupme-api-types"
-import type { Client } from ".."
-import { BaseManager, Collection, FormerGroupManager, Group, Member, User } from ".."
+import type { APIGroup } from 'groupme-api-types'
+import type { Client } from '..'
+import { BaseManager, Collection, FormerGroupManager, Group, Member, User } from '..'
 
 type GroupsRequestParams = {
     page?: number
     per_page?: number
-    omit?: "memberships"
+    omit?: 'memberships'
 }
 
 type FetchParams = {
@@ -49,12 +49,14 @@ export default class GroupManager extends BaseManager<Group> implements GroupMan
     fetch(id: string): Promise<Group>
     fetch(ids: string[]): Promise<Collection<string, Group | null>>
     fetch(options: FetchParams): Promise<Collection<string, Group | null>>
-    public async fetch(options?: string | string[] | FetchParams): Promise<Group | Collection<string, Group> | Collection<string, Group | null>> {
-        if (typeof options === "string") {
+    public async fetch(
+        options?: string | string[] | FetchParams,
+    ): Promise<Group | Collection<string, Group> | Collection<string, Group | null>> {
+        if (typeof options === 'string') {
             return await this.fetchId(options)
         } else if (options instanceof Array) {
             return await this.fetchIds(options)
-        } else if (typeof options === "object") {
+        } else if (typeof options === 'object') {
             return await this.fetchIndex(options)
         } else {
             return await this.fetchAll()
@@ -62,16 +64,16 @@ export default class GroupManager extends BaseManager<Group> implements GroupMan
     }
 
     private async fetchId(id: string): Promise<Group> {
-        const res = await this.client.rest.api<APIGroup>("GET", `groups/${id}`)
+        const res = await this.client.rest.api<APIGroup>('GET', `groups/${id}`)
         const group = this._upsert(new Group(this.client, res))
         if (res.members) {
-            res.members.forEach((data) => {
+            res.members.forEach(data => {
                 const user = this.client.users._upsert(
                     new User(this.client, {
                         id: data.user_id,
                         avatar: data.image_url,
                         name: data.name,
-                    })
+                    }),
                 )
                 group.members._upsert(new Member(this.client, group, user, data))
             })
@@ -82,10 +84,10 @@ export default class GroupManager extends BaseManager<Group> implements GroupMan
     private async fetchIds(ids: string[]): Promise<Collection<string, Group | null>> {
         const batch = new Collection<string, Group>()
         await Promise.all(
-            ids.map(async (id) => {
+            ids.map(async id => {
                 const group = await this.fetchId(id)
                 batch.set(group.id, group)
-            })
+            }),
         )
         return batch
     }
@@ -94,22 +96,22 @@ export default class GroupManager extends BaseManager<Group> implements GroupMan
         const apiParams: GroupsRequestParams = {}
         if (options.page !== undefined) apiParams.page = options.page
         if (options.per_page !== undefined) apiParams.per_page = options.per_page
-        if (options.omit_members === true) apiParams.omit = "memberships"
+        if (options.omit_members === true) apiParams.omit = 'memberships'
 
         const batch = new Collection<string, Group>()
-        const groupsIndexResponse = await this.client.rest.api<APIGroup[]>("GET", "groups", { query: apiParams })
-        groupsIndexResponse.forEach((g) => {
+        const groupsIndexResponse = await this.client.rest.api<APIGroup[]>('GET', 'groups', { query: apiParams })
+        groupsIndexResponse.forEach(g => {
             /** The Group object to store data in. */
             const group = this._upsert(new Group(this.client, g))
 
             if (g.members) {
-                g.members.forEach((data) => {
+                g.members.forEach(data => {
                     const user = this.client.users._upsert(
                         new User(this.client, {
                             id: data.user_id,
                             avatar: data.image_url,
                             name: data.name,
-                        })
+                        }),
                     )
                     group.members._upsert(new Member(this.client, group, user, data))
                 })

--- a/src/managers/GroupMessageManager.ts
+++ b/src/managers/GroupMessageManager.ts
@@ -1,7 +1,7 @@
-import type { GetGroupMessageResponse, GetGroupMessagesQuery, GetGroupMessagesResponse } from "groupme-api-types"
-import type { Client, Group } from ".."
-import { Collection, GroupMessage, MessageManager } from ".."
-import type { MessageRequestParams } from "./MessageManager"
+import type { GetGroupMessageResponse, GetGroupMessagesQuery, GetGroupMessagesResponse } from 'groupme-api-types'
+import type { Client, Group } from '..'
+import { Collection, GroupMessage, MessageManager } from '..'
+import type { MessageRequestParams } from './MessageManager'
 
 interface GroupMessageManagerInterface {
     client: Client
@@ -13,7 +13,10 @@ interface GroupMessageManagerInterface {
     fetch(options: MessageRequestParams): Promise<Collection<string, GroupMessage>>
 }
 
-export default class GroupMessageManager extends MessageManager<Group, GroupMessage> implements GroupMessageManagerInterface {
+export default class GroupMessageManager
+    extends MessageManager<Group, GroupMessage>
+    implements GroupMessageManagerInterface
+{
     constructor(client: Client, channel: Group) {
         super(client, channel, GroupMessage)
     }
@@ -22,12 +25,14 @@ export default class GroupMessageManager extends MessageManager<Group, GroupMess
     fetch(id: string): Promise<GroupMessage>
     fetch(ids: string[]): Promise<Collection<string, GroupMessage>>
     fetch(options: MessageRequestParams): Promise<Collection<string, GroupMessage>>
-    public async fetch(options?: string | string[] | MessageRequestParams): Promise<GroupMessage | Collection<string, GroupMessage>> {
-        if (typeof options === "string") {
+    public async fetch(
+        options?: string | string[] | MessageRequestParams,
+    ): Promise<GroupMessage | Collection<string, GroupMessage>> {
+        if (typeof options === 'string') {
             return await this.fetchId(options)
         } else if (Array.isArray(options)) {
             return await this.fetchIds(options)
-        } else if (typeof options === "object") {
+        } else if (typeof options === 'object') {
             return await this.fetchIndex(options)
         } else {
             return await this.fetchAll()
@@ -35,14 +40,17 @@ export default class GroupMessageManager extends MessageManager<Group, GroupMess
     }
 
     private async fetchId(id: string): Promise<GroupMessage> {
-        const res = await this.client.rest.api<GetGroupMessageResponse>("GET", `groups/${this.channel.id}/messages/${id}`)
+        const res = await this.client.rest.api<GetGroupMessageResponse>(
+            'GET',
+            `groups/${this.channel.id}/messages/${id}`,
+        )
         const message = this._upsert(new GroupMessage(this.client, this.channel, res.message))
         return message
     }
 
     private async fetchIds(ids: string[]): Promise<Collection<string, GroupMessage>> {
         const messages = await Promise.all(ids.map<Promise<GroupMessage>>(this.fetchId))
-        const batch = new Collection<string, GroupMessage>(messages.map((m) => [m.id, m]))
+        const batch = new Collection<string, GroupMessage>(messages.map(m => [m.id, m]))
         return batch
     }
 
@@ -54,7 +62,12 @@ export default class GroupMessageManager extends MessageManager<Group, GroupMess
         if (options.limit !== undefined) apiParams.limit = options.limit
 
         const batch = new Collection<string, GroupMessage>()
-        const res = await this.client.rest.api<GetGroupMessagesResponse>("GET", `groups/${this.channel.id}/messages`, { query: apiParams }, { allowNull: true })
+        const res = await this.client.rest.api<GetGroupMessagesResponse>(
+            'GET',
+            `groups/${this.channel.id}/messages`,
+            { query: apiParams },
+            { allowNull: true },
+        )
 
         if (!res) return batch
 

--- a/src/managers/MemberManager.ts
+++ b/src/managers/MemberManager.ts
@@ -1,5 +1,5 @@
-import type { BaseGroup, Client, Collection } from ".."
-import { BaseManager, FormerMemberManager, Member } from ".."
+import type { BaseGroup, Client, Collection } from '..'
+import { BaseManager, FormerMemberManager, Member } from '..'
 
 interface MemberManagerInterface {
     add(id: string): Promise<Member>
@@ -19,9 +19,9 @@ export default class MemberManager extends BaseManager<Member> implements Member
     add(id: string): Promise<Member>
     add(ids: string[]): Promise<Collection<string, Member>>
     add(ids: string | string[]): Promise<Member> | Promise<Collection<string, Member>> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
     remove(member: Member): Promise<this> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
 }

--- a/src/managers/MessageLikeManager.ts
+++ b/src/managers/MessageLikeManager.ts
@@ -1,4 +1,4 @@
-import { UserManager } from ".."
+import { UserManager } from '..'
 
 interface MessageLikeManagerInterface {
     get mine(): boolean

--- a/src/managers/MessageManager.ts
+++ b/src/managers/MessageManager.ts
@@ -1,5 +1,5 @@
-import type { Channel, Client, Collection, Message } from ".."
-import { BaseManager } from ".."
+import type { Channel, Client, Collection, Message } from '..'
+import { BaseManager } from '..'
 
 export type MessageRequestParams = {
     before_id?: string
@@ -15,7 +15,10 @@ interface MessageManagerInterface<T extends Message> {
     fetch(options: MessageRequestParams): Promise<Collection<string, T>>
 }
 
-export default abstract class MessageManager<T extends Channel, U extends Message> extends BaseManager<U> implements MessageManagerInterface<U> {
+export default abstract class MessageManager<T extends Channel, U extends Message>
+    extends BaseManager<U>
+    implements MessageManagerInterface<U>
+{
     readonly channel: T
     constructor(client: Client, channel: T, holds: new (client: Client, ...args: any) => U) {
         super(client, holds)

--- a/src/managers/PollManager.ts
+++ b/src/managers/PollManager.ts
@@ -1,5 +1,5 @@
-import type { Client, Collection, Group } from ".."
-import { BaseManager, Poll } from ".."
+import type { Client, Collection, Group } from '..'
+import { BaseManager, Poll } from '..'
 
 interface PollManagerInterface {
     fetch(): Promise<Collection<string, Poll>>
@@ -12,7 +12,7 @@ interface PollManagerInterface {
             endAt?: Date
             public?: boolean
             allowMultipleResponses?: boolean
-        }
+        },
     ): Promise<Poll>
 }
 
@@ -22,12 +22,16 @@ export default class PollManager extends BaseManager<Poll> implements PollManage
         super(client, Poll)
         this.group = group
     }
-    create(question: string, options: string[], settings?: { duration?: number; endAt?: Date; public?: boolean; allowMultipleResponses?: boolean }): Promise<Poll> {
-        throw new Error("Method not implemented.")
+    create(
+        question: string,
+        options: string[],
+        settings?: { duration?: number; endAt?: Date; public?: boolean; allowMultipleResponses?: boolean },
+    ): Promise<Poll> {
+        throw new Error('Method not implemented.')
     }
     fetch(): Promise<Collection<string, Poll>>
     fetch(id: string): Promise<Poll>
     fetch(id?: string): Promise<Collection<string, Poll> | Poll> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
 }

--- a/src/managers/UserManager.ts
+++ b/src/managers/UserManager.ts
@@ -1,5 +1,5 @@
-import type { Client } from ".."
-import { User, BaseManager } from ".."
+import type { Client } from '..'
+import { User, BaseManager } from '..'
 
 interface UserManagerInterface {}
 

--- a/src/rest/rest.ts
+++ b/src/rest/rest.ts
@@ -1,14 +1,16 @@
-import fetch, { Headers, RequestInit, Response } from "node-fetch"
-import { URL } from "url"
-import { inspect } from "util"
-import type { Client } from ".."
+import fetch, { Headers, RequestInit, Response } from 'node-fetch'
+import { URL } from 'url'
+import { inspect } from 'util'
+import type { Client } from '..'
 
 function assertDefined<T>(val: T, err: Error): asserts val is NonNullable<T> {
     if (val === undefined || val === null) throw err
 }
 
 function createAPIError(message: string, endpoint: URL, options: unknown, response: unknown): Error {
-    return new Error(`${message}\n-- Endpoint: ${endpoint}\n-- Options: ${inspect(options)}\n-- Response: ${inspect(response)}`)
+    return new Error(
+        `${message}\n-- Endpoint: ${endpoint}\n-- Options: ${inspect(options)}\n-- Response: ${inspect(response)}`,
+    )
 }
 
 function* i() {
@@ -19,7 +21,7 @@ function* i() {
     }
 }
 
-type HttpMethod = "GET" | "POST"
+type HttpMethod = 'GET' | 'POST'
 
 type RequestOptions = {
     query?: {
@@ -29,7 +31,7 @@ type RequestOptions = {
 }
 
 export default class RESTManager {
-    static BASE_URL = "https://api.groupme.com/v3/"
+    static BASE_URL = 'https://api.groupme.com/v3/'
     public client: Client
     private generator: Generator<number, void, unknown>
     constructor(client: Client) {
@@ -38,9 +40,24 @@ export default class RESTManager {
     }
 
     async api<T>(method: HttpMethod, path: string, data?: RequestOptions): Promise<T>
-    async api<T>(method: HttpMethod, path: string, data: RequestOptions, options: { skipJsonParse: true }): Promise<Response>
-    async api<T>(method: HttpMethod, path: string, data: RequestOptions, options: { allowNull: true }): Promise<T | null>
-    async api<T>(method: HttpMethod, path: string, data?: RequestOptions, options?: { skipJsonParse?: boolean; allowNull?: boolean }): Promise<T | Response | null> {
+    async api<T>(
+        method: HttpMethod,
+        path: string,
+        data: RequestOptions,
+        options: { skipJsonParse: true },
+    ): Promise<Response>
+    async api<T>(
+        method: HttpMethod,
+        path: string,
+        data: RequestOptions,
+        options: { allowNull: true },
+    ): Promise<T | null>
+    async api<T>(
+        method: HttpMethod,
+        path: string,
+        data?: RequestOptions,
+        options?: { skipJsonParse?: boolean; allowNull?: boolean },
+    ): Promise<T | Response | null> {
         const url = new URL(path, RESTManager.BASE_URL)
         if (data?.query) {
             for (const key in data.query) {
@@ -53,10 +70,10 @@ export default class RESTManager {
 
         const init: RequestInit = {}
         init.headers = new Headers()
-        init.headers.set("X-Access-Token", this.client.token)
+        init.headers.set('X-Access-Token', this.client.token)
         init.method = method
         if (data?.body) {
-            init.headers.set("Content-Type", "application/json")
+            init.headers.set('Content-Type', 'application/json')
             init.body = JSON.stringify(data.body)
         }
 
@@ -65,15 +82,15 @@ export default class RESTManager {
 
         if (options?.skipJsonParse) return response
         // for (const header of response.headers.entries()) // console.log(header)
-        if (response.headers.get("content-length") === "0") {
+        if (response.headers.get('content-length') === '0') {
             if (options?.allowNull) return null
-            else throw createAPIError("Received a response with Content-Length: 0, but expected content", url, data, {})
+            else throw createAPIError('Received a response with Content-Length: 0, but expected content', url, data, {})
         }
 
         const json = await response.json()
-        assertDefined(json, createAPIError("Invalid API response", url, data, json))
+        assertDefined(json, createAPIError('Invalid API response', url, data, json))
         assertDefined(json.meta, createAPIError('Response is missing "meta" field', url, data, json))
-        if (json.meta.errors) throw createAPIError(json.meta.errors.join("; "), url, data, json)
+        if (json.meta.errors) throw createAPIError(json.meta.errors.join('; '), url, data, json)
 
         const result: T = json.response as T
 
@@ -83,6 +100,6 @@ export default class RESTManager {
     guid(): string {
         return `node-groupme_${this.generator.next().value}_${Math.floor(Math.random() * 16 ** 6)
             .toString(16)
-            .padEnd(6, "0")}`
+            .padEnd(6, '0')}`
     }
 }

--- a/src/rest/rest.ts
+++ b/src/rest/rest.ts
@@ -24,9 +24,7 @@ function* i() {
 type HttpMethod = 'GET' | 'POST'
 
 type RequestOptions = {
-    query?: {
-        [key: string]: string
-    }
+    query?: Record<string, unknown>
     body?: unknown
 }
 
@@ -63,7 +61,7 @@ export default class RESTManager {
             for (const key in data.query) {
                 if (Object.prototype.hasOwnProperty.call(data.query, key)) {
                     const value = data.query[key]
-                    url.searchParams.set(key, value)
+                    url.searchParams.set(key, String(value))
                 }
             }
         }

--- a/src/structures/Attachment.ts
+++ b/src/structures/Attachment.ts
@@ -6,21 +6,21 @@ export default abstract class Attachment {
 }
 
 export class ImageAttachment extends Attachment {
-    type = "image"
+    type = 'image'
     url: string
     constructor(data: Omit<ImageAttachment, keyof Attachment>) {
-        super("image")
+        super('image')
         this.url = data.url
     }
 }
 
 export class LocationAttachment extends Attachment {
-    type = "location"
+    type = 'location'
     lat: string
     lng: string
     name: string
     constructor(data: Omit<LocationAttachment, keyof Attachment>) {
-        super("location")
+        super('location')
         this.lat = data.lat
         this.lng = data.lng
         this.name = data.name
@@ -28,20 +28,20 @@ export class LocationAttachment extends Attachment {
 }
 
 export class SplitAttachment extends Attachment {
-    type = "split"
+    type = 'split'
     token: string
     constructor(data: Omit<SplitAttachment, keyof Attachment>) {
-        super("split")
+        super('split')
         this.token = data.token
     }
 }
 
 export class EmojiAttachment extends Attachment {
-    type = "emoji"
+    type = 'emoji'
     placeholder: string
     charmap: [number, number][]
     constructor(data: Omit<EmojiAttachment, keyof Attachment>) {
-        super("emoji")
+        super('emoji')
         this.placeholder = data.placeholder
         this.charmap = data.charmap
     }

--- a/src/structures/BaseGroup.ts
+++ b/src/structures/BaseGroup.ts
@@ -1,6 +1,6 @@
-import type { APIGroup } from "groupme-api-types"
-import type { Client } from ".."
-import { Channel, MemberManager } from ".."
+import type { APIGroup } from 'groupme-api-types'
+import type { Client } from '..'
+import { Channel, MemberManager } from '..'
 
 export default abstract class BaseGroup extends Channel {
     readonly members: MemberManager
@@ -16,7 +16,7 @@ export default abstract class BaseGroup extends Channel {
     maxMembers: number
     theme: string | null
     likeIcon: {
-        type: "emoji"
+        type: 'emoji'
         packId: number
         packIndex: number
     } | null
@@ -46,7 +46,7 @@ export default abstract class BaseGroup extends Channel {
         this.members = new MemberManager(this.client, this)
         this.name = data.name
         this.phoneNumber = data.phone_number
-        this.closed = data.type == "closed"
+        this.closed = data.type == 'closed'
         this.imageURL = data.image_url
         this.creatorID = data.creator_user_id
         this.mutedUntil = data.muted_until
@@ -59,7 +59,7 @@ export default abstract class BaseGroup extends Channel {
             ? {
                   packId: data.like_icon.pack_id,
                   packIndex: data.like_icon.pack_index,
-                  type: "emoji",
+                  type: 'emoji',
               }
             : null
         this.requiresApproval = data.requires_approval

--- a/src/structures/Channel.ts
+++ b/src/structures/Channel.ts
@@ -1,9 +1,9 @@
-import type { Attachment, Client, Message, MessageManager } from ".."
+import type { Attachment, Client, Message, MessageManager } from '..'
 
 export enum ChannelType {
-    Chat = "chat",
-    Group = "group",
-    FormerGroup = "former_group",
+    Chat = 'chat',
+    Group = 'group',
+    FormerGroup = 'former_group',
 }
 
 type MessagePreview = {

--- a/src/structures/Chat.ts
+++ b/src/structures/Chat.ts
@@ -1,6 +1,6 @@
-import type { APIChat, PostChatMessageBody, PostChatMessageResponse } from "groupme-api-types"
-import type { Client, SendableChannelInterface, User } from ".."
-import { Channel, ChannelType, ChatMessage, ChatMessageManager } from ".."
+import type { APIChat, PostChatMessageBody, PostChatMessageResponse } from 'groupme-api-types'
+import type { Client, SendableChannelInterface, User } from '..'
+import { Channel, ChannelType, ChatMessage, ChatMessageManager } from '..'
 
 interface ChatInterface {
     send(text: string): Promise<ChatMessage>
@@ -44,7 +44,7 @@ export default class Chat extends Channel implements ChatInterface, SendableChan
                 recipient_id: this.recipient.id,
             },
         }
-        const response = await this.client.rest.api<PostChatMessageResponse>("POST", "direct_messages", { body })
+        const response = await this.client.rest.api<PostChatMessageResponse>('POST', 'direct_messages', { body })
         const message = new ChatMessage(this.client, this, response.direct_message)
         return this.messages._upsert(message)
     }

--- a/src/structures/ChatMessage.ts
+++ b/src/structures/ChatMessage.ts
@@ -1,4 +1,4 @@
-import { Message } from ".."
+import { Message } from '..'
 
 interface ChatMessageInterface {}
 

--- a/src/structures/FormerGroup.ts
+++ b/src/structures/FormerGroup.ts
@@ -1,6 +1,6 @@
-import type { APIGroup } from "groupme-api-types"
-import type { Client, Group } from ".."
-import { BaseGroup, ChannelType } from ".."
+import type { APIGroup } from 'groupme-api-types'
+import type { Client, Group } from '..'
+import { BaseGroup, ChannelType } from '..'
 
 interface FormerGroupInterface {
     rejoin(): Promise<Group>
@@ -15,6 +15,6 @@ export default class FormerGroup extends BaseGroup implements FormerGroupInterfa
     }
 
     rejoin(): Promise<Group> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
 }

--- a/src/structures/FormerMember.ts
+++ b/src/structures/FormerMember.ts
@@ -1,11 +1,11 @@
-import type { APIMember } from "groupme-api-types"
-import type { Client, Group, User } from ".."
-import { Member } from ".."
+import type { APIMember } from 'groupme-api-types'
+import type { Client, Group, User } from '..'
+import { Member } from '..'
 
 enum State {
-    Exited = "exited",
-    ExitedRemoved = "exited_removed",
-    Removed = "removed",
+    Exited = 'exited',
+    ExitedRemoved = 'exited_removed',
+    Removed = 'removed',
 }
 
 interface FormerMemberInterface {
@@ -20,9 +20,9 @@ export default class FormerMember extends Member implements FormerMemberInterfac
         this.state = state
     }
     ban(): Promise<this> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
     rejoin(): Promise<this> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
 }

--- a/src/structures/Group.ts
+++ b/src/structures/Group.ts
@@ -1,6 +1,14 @@
-import type { APIGroup, PostGroupMessageBody, PostGroupMessageResponse, PatchGroupBody, PatchGroupResponse, PostChangeOwnersBody, PostChangeOwnersResponse } from "groupme-api-types"
-import type { Client, FormerGroup, Member, SendableChannelInterface } from ".."
-import { BaseGroup, ChannelType, GroupMessage, GroupMessageManager, PollManager } from ".."
+import type {
+    APIGroup,
+    PostGroupMessageBody,
+    PostGroupMessageResponse,
+    PatchGroupBody,
+    PatchGroupResponse,
+    PostChangeOwnersBody,
+    PostChangeOwnersResponse,
+} from 'groupme-api-types'
+import type { Client, FormerGroup, Member, SendableChannelInterface } from '..'
+import { BaseGroup, ChannelType, GroupMessage, GroupMessageManager, PollManager } from '..'
 
 type GroupUpdateOptions = {
     name: string
@@ -38,7 +46,9 @@ export default class Group extends BaseGroup implements ActiveGroupInterface, Se
                 source_guid: this.client.rest.guid(),
             },
         }
-        const response = await this.client.rest.api<PostGroupMessageResponse>("POST", `groups/${this.id}/messages`, { body })
+        const response = await this.client.rest.api<PostGroupMessageResponse>('POST', `groups/${this.id}/messages`, {
+            body,
+        })
         const message = new GroupMessage(this.client, this, response.message)
         return this.messages._upsert(message)
     }
@@ -49,7 +59,7 @@ export default class Group extends BaseGroup implements ActiveGroupInterface, Se
 
     async update(options: GroupUpdateOptions): Promise<Group> {
         const body: PatchGroupBody = options
-        const response = await this.client.rest.api<PatchGroupResponse>("POST", `groups/${this.id}/update`, { body })
+        const response = await this.client.rest.api<PatchGroupResponse>('POST', `groups/${this.id}/update`, { body })
         const group = new Group(this.client, response)
         return this.client.groups._upsert(group)
     }
@@ -63,26 +73,28 @@ export default class Group extends BaseGroup implements ActiveGroupInterface, Se
                 },
             ],
         }
-        const response = await this.client.rest.api<PostChangeOwnersResponse>("POST", "groups/change_owners", { body })
+        const response = await this.client.rest.api<PostChangeOwnersResponse>('POST', 'groups/change_owners', { body })
         const status = response.results[0].status
-        let errorMessage = ""
+        let errorMessage = ''
         switch (status) {
-            case "200":
+            case '200':
                 return this.fetch()
-            case "400":
-                errorMessage = "You cannot transfer a group to yourself."
+            case '400':
+                errorMessage = 'You cannot transfer a group to yourself.'
                 break
-            case "403":
-                errorMessage = "You cannot transfer a group you do not own."
+            case '403':
+                errorMessage = 'You cannot transfer a group you do not own.'
                 break
-            case "404":
-                errorMessage = "Group not found, or new owner is not a member of the group."
+            case '404':
+                errorMessage = 'Group not found, or new owner is not a member of the group.'
                 break
-            case "405":
-                errorMessage = "Invalid request; Request object is missing a required field, or one of the required fields is not an ID."
+            case '405':
+                errorMessage =
+                    'Invalid request; Request object is missing a required field, or one of the required fields is not an ID.'
                 break
             default:
-                errorMessage = "Idk what this status code means, but it's probably an error. It wasn't on the docs and I've never seen it before. Please report this to the developers of node-groupme and/or the GroupMe API!"
+                errorMessage =
+                    "Idk what this status code means, but it's probably an error. It wasn't on the docs and I've never seen it before. Please report this to the developers of node-groupme and/or the GroupMe API!"
                 break
         }
         const err = {
@@ -96,15 +108,15 @@ export default class Group extends BaseGroup implements ActiveGroupInterface, Se
     }
 
     delete(): Promise<void> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
 
     changeNickname(nickname: string): Promise<Member> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
 
     leave(): Promise<FormerGroup> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
 
     public get me(): Member | undefined {

--- a/src/structures/GroupMessage.ts
+++ b/src/structures/GroupMessage.ts
@@ -1,6 +1,6 @@
-import type { APIGroupMessage } from "groupme-api-types"
-import type { Client, Group } from ".."
-import { Message } from ".."
+import type { APIGroupMessage } from 'groupme-api-types'
+import type { Client, Group } from '..'
+import { Message } from '..'
 
 interface GroupMessageInterface {}
 

--- a/src/structures/Member.ts
+++ b/src/structures/Member.ts
@@ -1,5 +1,5 @@
-import type { APIMember } from "groupme-api-types"
-import type { BaseGroup, Client, User } from ".."
+import type { APIMember } from 'groupme-api-types'
+import type { BaseGroup, Client, User } from '..'
 
 interface MemberInterface {}
 
@@ -12,7 +12,7 @@ export default class Member implements MemberInterface {
     nickname: string
     muted: boolean
     autokicked: boolean
-    roles: ("admin" | "owner" | "user")[]
+    roles: ('admin' | 'owner' | 'user')[]
 
     constructor(client: Client, group: BaseGroup, user: User, data: APIMember) {
         this.client = client
@@ -27,7 +27,7 @@ export default class Member implements MemberInterface {
     }
 
     get isAdmin(): boolean {
-        return this.roles.includes("admin") || this.isOwner
+        return this.roles.includes('admin') || this.isOwner
     }
 
     get isOwner(): boolean {

--- a/src/structures/Message.ts
+++ b/src/structures/Message.ts
@@ -1,6 +1,6 @@
-import type { APIChatMessage, APIGroupMessage } from "groupme-api-types"
-import type { Attachment, Channel, Client } from ".."
-import { User } from ".."
+import type { APIChatMessage, APIGroupMessage } from 'groupme-api-types'
+import type { Attachment, Channel, Client } from '..'
+import { User } from '..'
 
 interface MessageInterface {
     fetch(): Promise<this>
@@ -28,32 +28,32 @@ export default abstract class Message implements MessageInterface {
                 id: data.user_id,
                 avatar: data.avatar_url,
                 name: data.name,
-            })
+            }),
         )
         this.channel = channel
         this.text = data.text
         this.createdAt = data.created_at
         this.sourceGuid = data.source_guid
-        this.system = "system" in data ? data.system : false
-        this.likes = data.favorited_by.map((id) => client.users.cache.get(id) || id)
+        this.system = 'system' in data ? data.system : false
+        this.likes = data.favorited_by.map(id => client.users.cache.get(id) || id)
         this.attachments = data.attachments
     }
     fetch(): Promise<this> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
     reply(message: string): Promise<Message> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
     like(): Promise<this> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
     unlike(): Promise<this> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
     delete(): Promise<this> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
     get canDelete(): boolean {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
 }

--- a/src/structures/Poll.ts
+++ b/src/structures/Poll.ts
@@ -1,6 +1,6 @@
-import type { APIPoll } from "groupme-api-types"
-import type { Client, Group, PollOption, User } from ".."
-import { Collection } from ".."
+import type { APIPoll } from 'groupme-api-types'
+import type { Client, Group, PollOption, User } from '..'
+import { Collection } from '..'
 
 interface PollInterface {
     fetch(): Promise<this>
@@ -35,32 +35,36 @@ export default class Poll implements PollInterface {
         this.question = data.data.subject
         this.group = group
         this.creator = creator
-        this._active = data.data.status == "active"
-        this.multi = data.data.type == "multi"
-        this.public = data.data.visibility == "public"
+        this._active = data.data.status == 'active'
+        this.multi = data.data.type == 'multi'
+        this.public = data.data.visibility == 'public'
         this.createdAt = data.data.created_at
         this.updatedAt = data.data.last_modified
         this.expiresAt = data.data.expiration
         this.options = new Collection<OptionID, PollOption>()
-        this.voters = this.public ? (this.multi ? new Collection<UserID, OptionID[]>() : new Collection<UserID, OptionID>()) : undefined
+        this.voters = this.public
+            ? this.multi
+                ? new Collection<UserID, OptionID[]>()
+                : new Collection<UserID, OptionID>()
+            : undefined
         this.myVote = this.multi ? data.user_votes : data.user_vote
     }
     vote(option: string | PollOption): Promise<this>
     vote(options: (string | PollOption)[]): Promise<this>
     vote(options: string | PollOption | (string | PollOption)[]): Promise<this> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
     fetch(): Promise<this> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
     end(): Promise<this> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
     get canEnd(): boolean {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
     public get active(): boolean {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
         if (this._active /* && (this.expiresAt has passed) */) this._active = false
         return this._active
     }

--- a/src/structures/PollOption.ts
+++ b/src/structures/PollOption.ts
@@ -1,6 +1,6 @@
-import type { PollOptionData } from "groupme-api-types"
-import type { Poll, User } from ".."
-import { Collection } from ".."
+import type { PollOptionData } from 'groupme-api-types'
+import type { Poll, User } from '..'
+import { Collection } from '..'
 
 interface PollOptionInterface {
     vote(): Promise<this>
@@ -20,6 +20,6 @@ export default class PollOption implements PollOptionInterface {
         this.voters = new Collection<string, User>()
     }
     vote(): Promise<this> {
-        throw new Error("Method not implemented.")
+        throw new Error('Method not implemented.')
     }
 }

--- a/src/structures/User.ts
+++ b/src/structures/User.ts
@@ -1,4 +1,4 @@
-import type { Client } from ".."
+import type { Client } from '..'
 
 export type UserData = {
     id: string

--- a/src/util/Collection.ts
+++ b/src/util/Collection.ts
@@ -1,1 +1,1 @@
-export { default as Collection } from "@discordjs/collection"
+export { default as Collection } from '@discordjs/collection'

--- a/src/util/Websocket.ts
+++ b/src/util/Websocket.ts
@@ -1,7 +1,7 @@
-import { ok } from "assert"
-import EventEmitter from "events"
-import WebSocket from "ws"
-import type { Client } from ".."
+import { ok } from 'assert'
+import EventEmitter from 'events'
+import WebSocket from 'ws'
+import type { Client } from '..'
 
 export default class WS {
     client: Client
@@ -15,22 +15,22 @@ export default class WS {
     }
     init = async () =>
         new Promise<void>((resolve, reject) => {
-            this.ws = new WebSocket("wss://push.groupme.com/faye")
-                .on("open", () => {
+            this.ws = new WebSocket('wss://push.groupme.com/faye')
+                .on('open', () => {
                     this.handshake()
                 })
-                .on("message", (data) => this.handle(data))
+                .on('message', data => this.handle(data))
             this.channels
-                .once("/meta/handshake", (data) => {
-                    if (!this.client.user) return reject("Client user must be defined before init")
+                .once('/meta/handshake', data => {
+                    if (!this.client.user) return reject('Client user must be defined before init')
                     this.client_id = data.clientId
                     this.subscribe(`/user/${this.client.user.id}`)
                 })
-                .once("/meta/subscribe", (data) => {
+                .once('/meta/subscribe', data => {
                     this.connect()
                     resolve()
                 })
-                .on("/meta/connect", (data) => {
+                .on('/meta/connect', data => {
                     this.connect()
                 })
             // this.debug();
@@ -47,9 +47,9 @@ export default class WS {
         data.id = this.request_id++
         data.clientId = this.client_id
         const str = JSON.stringify([data])
-        this.ws.send(str, (err) => {
+        this.ws.send(str, err => {
             if (err) {
-                console.error("An error occurred while trying to send:", data)
+                console.error('An error occurred while trying to send:', data)
                 throw err
             }
             // console.log('SENT:', data)
@@ -57,22 +57,22 @@ export default class WS {
     }
     private handshake = () => {
         this.send({
-            channel: "/meta/handshake",
-            version: "1.0",
-            supportedConnectionTypes: ["websocket"],
+            channel: '/meta/handshake',
+            version: '1.0',
+            supportedConnectionTypes: ['websocket'],
         })
     }
     private subscribe = (channel: string) => {
         this.send({
-            channel: "/meta/subscribe",
+            channel: '/meta/subscribe',
             subscription: channel,
             ext: { access_token: this.client.token },
         })
     }
     private connect = () => {
         this.send({
-            channel: "/meta/connect",
-            connectionType: "websocket",
+            channel: '/meta/connect',
+            connectionType: 'websocket',
         })
     }
 
@@ -84,36 +84,36 @@ export default class WS {
         ok(this.ws)
 
         this.ws
-            .on("open", () => {
-                console.log("Event: OPEN")
+            .on('open', () => {
+                console.log('Event: OPEN')
             })
-            .on("upgrade", (request) => {
-                console.log("Event: UPGRADE")
-                console.log("Request:", request.headers)
+            .on('upgrade', request => {
+                console.log('Event: UPGRADE')
+                console.log('Request:', request.headers)
             })
-            .on("close", (code, reason) => {
-                console.log("Event: CLOSE")
-                console.log("Code:", code)
-                console.log("Reason:", reason.toString())
+            .on('close', (code, reason) => {
+                console.log('Event: CLOSE')
+                console.log('Code:', code)
+                console.log('Reason:', reason.toString())
                 console.log()
             })
-            .on("message", (data) => {
-                console.log("MESSAGE:", JSON.parse(data.toString())[0])
+            .on('message', data => {
+                console.log('MESSAGE:', JSON.parse(data.toString())[0])
             })
-            .on("ping", (data) => {
-                console.log("PING:", data.toString())
+            .on('ping', data => {
+                console.log('PING:', data.toString())
             })
-            .on("pong", (data) => {
-                console.log("PONG:", data.toString())
+            .on('pong', data => {
+                console.log('PONG:', data.toString())
             })
-            .on("error", (err) => {
-                console.log("Event: ERROR")
-                console.log("Error:", err)
+            .on('error', err => {
+                console.log('Event: ERROR')
+                console.log('Error:', err)
             })
-            .on("unexpected-response", (request, response) => {
-                console.log("Event: UNEXPECTED RESPONSE")
-                console.log("Request:", request.getHeaders())
-                console.log("Response:", response.headers)
+            .on('unexpected-response', (request, response) => {
+                console.log('Event: UNEXPECTED RESPONSE')
+                console.log('Request:', request.getHeaders())
+                console.log('Response:', response.headers)
             })
     }
 }


### PR DESCRIPTION
This PR adds some rules to `.prettierrc` and adds a `.gitattributes` file which hopefully tells Git not to convert line endings on Windows machines. Previously, Git would convert line endings to `CRLF` when checking out, and then Prettier would get angry and convert them back to `LF` causing a bunch of pointless empty changes which would need to be committed.

Also, I fixed some build issues which were introduced the last time around in #80.