### PR TITLE
ci: re-enable tests on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 name: Test Suite
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
     tests:


### PR DESCRIPTION
I’m hoping the secret passes properly, but if not, I’m going to need to rewrite the way the tests automatically run to allow that to connect without making the token public