### PR TITLE
ci: :green_heart: disable body-max-line-length rule for commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,7 @@
-module.exports = { 
-    extends: ["@commitlint/config-conventional"],
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
     rules: {
-        "subject-case": [1, "always", ["lower-case"]],
-    }
+        'subject-case': [1, 'always', ['lower-case']],
+        'body-max-line-length': [0],
+    },
 }


### PR DESCRIPTION
this rule is super annoying, plus it completely breaks semantic-release so now we have an excuse to get rid of it. P.S. this line is super long so we'll know that the rule is properly disabled if this commit goes through