### PR TITLE
refactor: :fire: remove Member#autokicked

### DIFF
--- a/src/structures/Member.ts
+++ b/src/structures/Member.ts
@@ -11,7 +11,7 @@ export default class Member implements MemberInterface {
     readonly id: string
     nickname: string
     muted: boolean
-    autokicked: boolean
+    // autokicked: boolean
     roles: ('admin' | 'owner' | 'user')[]
 
     constructor(client: Client, group: BaseGroup, user: User, data: APIMember) {
@@ -22,7 +22,7 @@ export default class Member implements MemberInterface {
         this.memberID = data.id
         this.nickname = data.nickname
         this.muted = data.muted
-        this.autokicked = data.autokicked
+        // this.autokicked = data.autokicked
         this.roles = data.roles
     }
 


### PR DESCRIPTION
changes to the groupme-api-types package reveal that the autokicked property is not always available on members. Let's remove this property until we have proper support for partials.

BREAKING CHANGE: Member#autokicked is gone