### PR TITLE
chore: :arrow_up: update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@discordjs/collection": "^0.1.6",
-        "groupme-api-types": "^2.0.0",
+        "groupme-api-types": "^2.1.0",
         "node-fetch": "^2.6.1",
         "ws": "^8.1.0"
       },
@@ -408,7 +408,8 @@
     "node_modules/@discordjs/collection": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
-      "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ=="
+      "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ==",
+      "deprecated": "no longer supported"
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.0",
@@ -3047,9 +3048,9 @@
       }
     },
     "node_modules/groupme-api-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/groupme-api-types/-/groupme-api-types-2.0.0.tgz",
-      "integrity": "sha512-dlCPFgvmx5X5zfa01DKqEeIGm2vO6vFuR/Ru5thvFmmVZdSgzKcy9OIFYHdrdaPBwST1ZQ8AF9rVkS9niZqWGQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/groupme-api-types/-/groupme-api-types-2.1.0.tgz",
+      "integrity": "sha512-0TVMeNGt04s1HCN0OqhYTW8Wp2ZE+Pog3C36V+iYB4WdHF52BNss3ivudc94lzHSDTacYkxpaOcNTLpeww1zYw=="
     },
     "node_modules/growl": {
       "version": "1.10.5",
@@ -11434,9 +11435,9 @@
       "dev": true
     },
     "groupme-api-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/groupme-api-types/-/groupme-api-types-2.0.0.tgz",
-      "integrity": "sha512-dlCPFgvmx5X5zfa01DKqEeIGm2vO6vFuR/Ru5thvFmmVZdSgzKcy9OIFYHdrdaPBwST1ZQ8AF9rVkS9niZqWGQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/groupme-api-types/-/groupme-api-types-2.1.0.tgz",
+      "integrity": "sha512-0TVMeNGt04s1HCN0OqhYTW8Wp2ZE+Pog3C36V+iYB4WdHF52BNss3ivudc94lzHSDTacYkxpaOcNTLpeww1zYw=="
     },
     "growl": {
       "version": "1.10.5",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@discordjs/collection": "^0.1.6",
-    "groupme-api-types": "^2.0.0",
+    "groupme-api-types": "^2.1.0",
     "node-fetch": "^2.6.1",
     "ws": "^8.1.0"
   },


### PR DESCRIPTION
`groupme-api-types@2.1.0`

this is mainly just to test the CI and make sure semantic-release bot is working, but it also allows us to implement `Message#like()` and other methods using the /likes endpoint.